### PR TITLE
fix: use context manager when manipulating GzipFiles (LP: #2051512)

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -364,7 +364,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
                     pass
             elif ext == ".gz":
                 try:
-                    report[key] = gzip.GzipFile(fileobj=attachment).read()
+                    with gzip.GzipFile(fileobj=attachment) as decompressor:
+                        report[key] = decompressor.read()
                 except OSError as error:
                     # some attachments are only called .gz, but are
                     # uncompressed (LP #574360)

--- a/problem_report.py
+++ b/problem_report.py
@@ -221,7 +221,8 @@ class CompressedValue:
     def set_value(self, value: bytes) -> None:
         """Set uncompressed value."""
         out = io.BytesIO()
-        gzip.GzipFile(self.name, mode="wb", fileobj=out, mtime=0).write(value)
+        with gzip.GzipFile(self.name, mode="wb", fileobj=out, mtime=0) as compressor:
+            compressor.write(value)
         self.compressed_value = out.getvalue()
 
     def get_compressed_size(self) -> int:
@@ -267,7 +268,7 @@ class CompressedValue:
         if self.compressed_value.startswith(ZSTANDARD_MAGIC_NUMBER):
             return _get_zstandard_decompressor().decompress(self.compressed_value)
         if self.compressed_value.startswith(GZIP_HEADER_START):
-            return gzip.GzipFile(fileobj=io.BytesIO(self.compressed_value)).read()
+            return gzip.decompress(self.compressed_value)
         # legacy zlib format
         return zlib.decompress(self.compressed_value)
 
@@ -281,13 +282,13 @@ class CompressedValue:
             return
 
         if self.compressed_value.startswith(GZIP_HEADER_START):
-            gz = gzip.GzipFile(fileobj=io.BytesIO(self.compressed_value))
-            while True:
-                block = gz.read(1048576)
-                if not block:
-                    break
-                file.write(block)
-            return
+            with gzip.GzipFile(fileobj=io.BytesIO(self.compressed_value)) as decompressor:
+                while True:
+                    block = decompressor.read(1048576)
+                    if not block:
+                        break
+                    file.write(block)
+                return
 
         # legacy zlib format
         file.write(zlib.decompress(self.compressed_value))
@@ -816,14 +817,13 @@ class ProblemReport(collections.UserDict):
                     attach_value = f.read()
                 else:
                     out = io.BytesIO()
-                    gf = gzip.GzipFile(k, mode="wb", fileobj=out, mtime=0)
-                    while True:
-                        block = f.read(1048576)
-                        if block:
-                            gf.write(block)
-                        else:
-                            gf.close()
-                            break
+                    with gzip.GzipFile(k, mode="wb", fileobj=out, mtime=0) as compressor:
+                        while True:
+                            block = f.read(1048576)
+                            if block:
+                                compressor.write(block)
+                            else:
+                                break
                     attach_value = out.getvalue()
                 f.close()
 

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -234,6 +234,10 @@ class T(unittest.TestCase):
         dmesgfile = os.path.join(vmcore_dir, f"dmesg.{timedir}")
         with open(dmesgfile, "wt", encoding="utf-8") as dmesg:
             dmesg.write("1" * 100)
+        vmcore_dir2 = pathlib.Path(apport.fileutils.report_dir) / "20240110211337"
+        vmcore_dir2.mkdir()
+        wrongly_named = vmcore_dir2 / "dmesg.wrongly-named"
+        wrongly_named.write_bytes(b"2" * 80)
 
         self.assertEqual(
             subprocess.call(self.data_dir / "kernel_crashdump", env=self.env),

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -427,8 +427,8 @@ class T(unittest.TestCase):
                 temp.write(bin_data)
                 temp.flush()
 
-                with gzip.GzipFile("File1", "w", fileobj=tempgz) as gz:
-                    gz.write(bin_data)
+                with gzip.GzipFile("File1", "w", fileobj=tempgz) as compressor:
+                    compressor.write(bin_data)
                 tempgz.flush()
 
                 pr = problem_report.ProblemReport(date="now!")
@@ -538,4 +538,5 @@ class T(unittest.TestCase):
         with tempfile.TemporaryFile() as payload:
             payload.write(message.get_payload(decode=True))
             payload.seek(0)
-            return gzip.GzipFile(mode="rb", fileobj=payload).read()
+            with gzip.GzipFile(mode="rb", fileobj=payload) as decompressor:
+                decompressor.read()

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1199,17 +1199,25 @@ class T(unittest.TestCase):
     def test_wait_for_gdb_child_process(self, sleep_mock):
         """Test wait_for_gdb_child_process() helper method."""
         child = MagicMock(spec=psutil.Process)
-        child.status.side_effect = ["tracing-stop", "sleeping"]
-        child.cmdline.return_value = [self.TEST_EXECUTABLE] + self.TEST_ARGS
+        child.status.side_effect = ["tracing-stop", "running", "sleeping"]
+        child.cmdline.side_effect = [
+            ["/bin/sh", "-c", f"exec {self.TEST_EXECUTABLE}"],
+            [self.TEST_EXECUTABLE] + self.TEST_ARGS,
+        ]
         with unittest.mock.patch("psutil.Process", spec=psutil.Process) as process_mock:
             process_mock.return_value.children.side_effect = [
                 [],
                 [child],  # child not started (tracing-stop)
+                [child],  # shell wrapper running
                 [child],  # child ready
             ]
+
             self.wait_for_gdb_child_process(123456789, self.TEST_EXECUTABLE)
+
         sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 2)
+        self.assertEqual(sleep_mock.call_count, 3)
+        self.assertEqual(child.status.call_count, 3)
+        self.assertEqual(child.cmdline.call_count, 2)
 
     @unittest.mock.patch("psutil.Process", spec=psutil.Process)
     @unittest.mock.patch("time.sleep")

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from problem_report import ProblemReport
 from tests.helper import import_module_from_file
 from tests.paths import get_data_directory
 
@@ -135,6 +136,27 @@ DISASM = """\
 
 class TestHookParseSegv(unittest.TestCase):
     """Test Segfault Parser."""
+
+    def test_add_info_without_segv_reason(self) -> None:
+        """Test add_info() with no SegvReason in result."""
+        report = ProblemReport()
+        report["Signal"] = "11"
+        report["Architecture"] = "amd64"
+        report["Disassembly"] = DISASM
+        report["ProcMaps"] = MAPS
+        report["Registers"] = REGS64
+
+        parse_segv.add_info(report)
+
+        self.assertEqual(
+            report.get("SegvAnalysis"),
+            "Segfault happened at: 0x08083540 <main+0>:    lea    0x4(%esp),%ecx\n"
+            "PC (0x08083540) ok\n"
+            "insn (lea) does not access VMA\n"
+            "SP (0xbfc6af24) ok\n"
+            "Reason could not be automatically determined.",
+        )
+        self.assertNotIn("SegvReason", report)
 
     def test_invalid_00_registers(self):
         """Require valid registers."""


### PR DESCRIPTION
Those objects are technically file-like objects, with the associated semantics. In particular, starting with Python 3.12 the class using internal buffering, which means write() calls won't necessarily directly be reflected in the underlying storage object.

For the sake of consistency, the context manager approach has been generalized to read() calls as well, except when we could get away with removing the use of GzipFile altogether.